### PR TITLE
Remove unused alias

### DIFF
--- a/lib/skooma.ex
+++ b/lib/skooma.ex
@@ -1,6 +1,5 @@
 defmodule Skooma do
   require Logger
-  alias Skooma.Utils
   alias Skooma.Basic
 
   def valid?(data, schema, path \\ []) do


### PR DESCRIPTION
Removed unused alias causing warnings during compilation

```
Compiling 5 files (.ex)
warning: unused alias Utils
  lib/skooma.ex:3
```